### PR TITLE
Change set_golem_wd() behaviour

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -59,7 +59,7 @@ set_golem_wd <- function(
   path, 
   talkative = TRUE
 ){
-  path <- normalizePath(path)
+  path <- normalizePath(path, winslash = "/")
   if (talkative){
     cat_green_tick(
       sprintf("Definining golem working directory as `%s`", path)


### PR DESCRIPTION
In Windows, original behaviours of set_golem_wd() creates path as "path\\to\\wd". 
This works fine until add_dockerfile_xxx(), which invokes usethis::use_build_ignore(). 
The function adds "^path\to\wd\Docker$" into the .Rbuildignore file. 
The regex triggers invalid regular expression errors when running devtools::check() and devtools::build().

Can be solved by adding argument winslash = "/" to the normalizePath() function within set_golem_wd()